### PR TITLE
feat: 種別個体数を表示する POPULATION HUD パネルを追加する

### DIFF
--- a/app/src/features/boids/components/PopulationPanel.tsx
+++ b/app/src/features/boids/components/PopulationPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
-import type { SpeciesCounts } from './BoidsCanvas';
+import { useEffect, useRef } from 'react';
+import type { SpeciesCounts } from '../lib/speciesUtils';
 import {
   BoidSpecies,
   SPECIES_SPRITES,
@@ -39,6 +39,8 @@ function drawSpriteIcon(
   sprite: ReadonlyArray<ReadonlyArray<0 | 1>>,
   color: string
 ): void {
+  if (sprite.length === 0) return;
+
   ctx.clearRect(0, 0, ICON_CANVAS_SIZE, ICON_CANVAS_SIZE);
   ctx.fillStyle = color;
   ctx.shadowBlur = 6;
@@ -63,14 +65,12 @@ function drawSpriteIcon(
   }
 }
 
-// スプライトアイコンコンポーネント
-function SpriteIcon({
-  species,
-  isShark,
-}: {
-  species?: BoidSpecies;
-  isShark?: boolean;
-}) {
+// スプライトアイコンコンポーネント（species か isShark のどちらか一方を必須とする）
+type SpriteIconProps =
+  | { species: BoidSpecies; isShark?: never }
+  | { species?: never; isShark: true };
+
+function SpriteIcon({ species, isShark }: SpriteIconProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {

--- a/app/src/features/boids/components/TerminalWindow.tsx
+++ b/app/src/features/boids/components/TerminalWindow.tsx
@@ -1,19 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import BoidsCanvas, { type SpeciesCounts } from './BoidsCanvas';
+import BoidsCanvas from './BoidsCanvas';
 import PopulationPanel from './PopulationPanel';
-import { BOID_COUNT, PREDATOR_COUNT, BoidSpecies } from '../lib/constants';
-
-// 初期状態を生成する
-function initializeCounts(): SpeciesCounts {
-  return Object.fromEntries(
-    Object.values(BoidSpecies).map(s => [s, 0])
-  ) as SpeciesCounts;
-}
+import { BOID_COUNT, PREDATOR_COUNT } from '../lib/constants';
+import { type SpeciesCounts, createEmptySpeciesCounts } from '../lib/speciesUtils';
 
 export default function TerminalWindow() {
-  const [counts, setCounts] = useState<SpeciesCounts>(initializeCounts());
+  const [counts, setCounts] = useState<SpeciesCounts>(createEmptySpeciesCounts);
   return (
     // ページ全体：暗いグレー背景
     <div className="min-h-screen bg-[#111111] flex items-center justify-center p-4 sm:p-6 lg:p-8">

--- a/app/src/features/boids/lib/speciesUtils.ts
+++ b/app/src/features/boids/lib/speciesUtils.ts
@@ -1,5 +1,15 @@
 import { BoidSpecies } from './constants';
 
+// 種別ごとの個体数を表す型
+export type SpeciesCounts = Record<BoidSpecies, number>;
+
+// 全種別のカウントが 0 の初期オブジェクトを生成する
+export function createEmptySpeciesCounts(): SpeciesCounts {
+  return Object.fromEntries(
+    Object.values(BoidSpecies).map(s => [s, 0])
+  ) as SpeciesCounts;
+}
+
 // ランダム割り当て時の重み（イワシを多めに）
 const SPECIES_WEIGHT_TABLE = [
   [BoidSpecies.Sardine,   35],


### PR DESCRIPTION
## Summary

- `PopulationPanel` コンポーネントを新規作成し、各種 Boid（7種）とサメの個体数をドット絵アイコン付きで右サイドバーに表示
- `BoidsCanvas` に `onCountsUpdate` コールバックを追加し、500ms ごとに種別ごとの個体数を集計して通知
- `TerminalWindow` を横並びレイアウトに変更し、右側に `PopulationPanel` を配置
- ドット絵アイコンをピクセルサイズ 2px・キャンバス内センタリングで見やすく調整

## Test plan

- [ ] 開発サーバー起動後、右サイドバーに `POPULATION` パネルが表示されること
- [ ] 各種 Boid の個体数が約 500ms 間隔でリアルタイム更新されること
- [ ] ドット絵アイコンが種ごとに正しい色・形で中央揃えされて表示されること
- [ ] サメに捕食されると対象種のカウントが減少すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)