### PR TITLE
UI改善：アプリ名・ターミナルデザインの調整・iPad Safari対応

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -35,3 +35,25 @@ canvas {
   display: block;
   image-rendering: pixelated;
 }
+
+/* ターミナル風スクロールバー（ダーク・細め）*/
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: #111111;
+}
+::-webkit-scrollbar-thumb {
+  background: #444;
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #666;
+}
+
+/* Firefox 向け scrollbar-color */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #444 #111111;
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -10,8 +10,8 @@ const pressStart2P = Press_Start_2P({
 });
 
 export const metadata: Metadata = {
-  title: "BOIDS",
-  description: "Boids simulation — インベーダーゲーム風群れシミュレーション",
+  title: "OCEAN-BOIDS",
+  description: "Ocean Boids — 海洋生物の群れシミュレーション",
 };
 
 export default function RootLayout({

--- a/app/src/features/boids/components/TerminalWindow.tsx
+++ b/app/src/features/boids/components/TerminalWindow.tsx
@@ -20,10 +20,10 @@ export default function TerminalWindow() {
       {/* ターミナルウィンドウ本体 */}
       <div
         className="w-full max-w-5xl flex flex-col border border-[#444] rounded-lg overflow-hidden shadow-[0_0_40px_rgba(0,0,0,0.8)]"
-        style={{ height: 'min(90vh, 760px)' }}
+        style={{ height: 'min(90dvh, 760px)' }}
       >
         {/* ── ウィンドウクローム：タイトルバーのみ ── */}
-        <div className="flex items-center gap-3 px-4 py-3 bg-[#252525] border-b border-[#444] shrink-0">
+        <div className="flex items-center gap-3 px-4 py-1.5 bg-[#252525] border-b border-[#444] shrink-0">
           {/* macOS 風トラフィックライト */}
           <div className="flex gap-1.5 shrink-0">
             <div className="w-3 h-3 rounded-full bg-[#ff5f57]" />
@@ -31,7 +31,7 @@ export default function TerminalWindow() {
             <div className="w-3 h-3 rounded-full bg-[#28c840]" />
           </div>
           {/* ウィンドウタイトル */}
-          <span className="font-mono text-sm text-[#666]">boids — swarm</span>
+          <span className="font-mono text-sm text-[#666]">ocean-boids — ocean</span>
         </div>
 
         {/* ── ターミナル本文 ── */}
@@ -42,20 +42,20 @@ export default function TerminalWindow() {
             <div className="px-4 pt-3 pb-2.5 border-b border-[#1e1e1e] shrink-0 font-mono text-xs leading-relaxed">
               {/* プロンプト行 */}
               <div className="flex items-center gap-2">
-                <span className="text-[#e8a046]">swarm</span>
-                <span className="text-[#888]">~/boids</span>
+                <span className="text-[#e8a046]">ocean</span>
+                <span className="text-[#888]">~/ocean-boids</span>
                 <span className="text-[#6eb3e8]">main ✦</span>
               </div>
               {/* 入力されたコマンド */}
               <div className="flex items-center gap-2 mt-0.5">
                 <span className="text-[#00ff41]">❯</span>
                 <span className="text-[#ddd]">
-                  spawn --creatures {simParams.boidCount} --sharks {PREDATOR_COUNT}
+                  spawn --fish {simParams.boidCount} --sharks {PREDATOR_COUNT} --biome ocean
                 </span>
               </div>
               {/* コマンドの出力 */}
               <div className="mt-1 text-[#666]">
-                Spawning {simParams.boidCount} ocean creatures and {PREDATOR_COUNT} shark into the depths...
+                Spawning {simParams.boidCount} fish and {PREDATOR_COUNT} sharks into the depths...
               </div>
             </div>
 
@@ -81,7 +81,7 @@ export default function TerminalWindow() {
         <div className="px-4 py-2.5 bg-[#1a1a1a] border-t border-[#333] shrink-0 font-mono text-xs">
           <div className="flex gap-4 text-[#555]">
             <span>
-              creatures:{' '}
+              fish:{' '}
               <span className="text-[#00ff41]">{simParams.boidCount}</span>
             </span>
             <span>


### PR DESCRIPTION
## 概要

リポジトリ名変更（→ ocean-boids）に合わせたアプリ名の更新と、ターミナル風UIのデザイン改善を行いました。

## 変更点

- アプリ名を `BOIDS` → `OCEAN-BOIDS` に変更、descriptionも海洋テーマに更新
- TerminalWindowのタイトルバー・プロンプトのユーザー名を `swarm` → `ocean` テーマに変更
- タイトルバーの高さを `py-3` → `py-1.5` に縮小
- spawnコマンドを `--creatures` → `--fish --biome ocean` 形式に変更、フッターも合わせて更新
- `90vh` → `90dvh` に変更してiPad Safariでのレイアウト崩れを修正
- ターミナル風スクロールバー（ダーク・細め）を `globals.css` に追加

Closes #22