### PR TITLE
feat: クラゲ捕食時に捕食者をしびれ状態にするエフェクトを実装

### DIFF
--- a/app/src/features/boids/lib/Predator.ts
+++ b/app/src/features/boids/lib/Predator.ts
@@ -125,6 +125,7 @@ export class Predator {
     const effectiveMaxForce = PREDATOR_MAX_FORCE * speedMultiplier;
 
     // 1回の走査で追尾力と捕食対象を計算（chase/eat の重複計算を統合）
+    // しびれ中も捕食スキャンは実行する（停止中にクラゲと接触した場合も満腹度を増加し、しびれ時間をリセットする仕様）
     const { steer, eaten } = this.scanBoids(boids, width, height, effectiveSpeed, effectiveMaxForce);
 
     // クラゲを捕食したらしびれ状態にする（既にしびれ中でも時間をリセット）

--- a/app/src/features/boids/lib/constants.ts
+++ b/app/src/features/boids/lib/constants.ts
@@ -251,10 +251,12 @@ export const DEFAULT_SIM_PARAMS: SimParams = {
 };
 
 // しびれエフェクトのパラメータ
-export const PREDATOR_STUN_DURATION_MS = 3000;      // しびれ持続時間（ミリ秒）
-export const PREDATOR_STUN_DOT_COUNT   = 6;         // しびれエフェクトのドット数
-export const PREDATOR_STUN_DOT_ORBIT   = 28;        // ドットの回転軌道半径（px）
-export const PREDATOR_STUN_COLOR       = '#ffee00'; // しびれエフェクトの色（黄色）
+export const PREDATOR_STUN_DURATION_MS  = 3000;      // しびれ持続時間（ミリ秒）
+export const PREDATOR_STUN_DOT_COUNT    = 6;         // しびれエフェクトのドット数
+export const PREDATOR_STUN_DOT_ORBIT    = 28;        // ドットの回転軌道半径（px）
+export const PREDATOR_STUN_DOT_RADIUS   = 3;         // ドットの描画半径（px）
+export const PREDATOR_STUN_ORBIT_WOBBLE = 4;         // 軌道半径の振動幅（px）しびれ感を演出
+export const PREDATOR_STUN_COLOR: `#${string}` = '#ffee00'; // しびれエフェクトの色（黄色）
 
 // ── CRTエフェクトのパラメータ ─────────────────────────────────────────────
 

--- a/app/src/features/boids/lib/predatorRenderer.ts
+++ b/app/src/features/boids/lib/predatorRenderer.ts
@@ -6,6 +6,8 @@ import {
   PREDATOR_STUN_COLOR,
   PREDATOR_STUN_DOT_COUNT,
   PREDATOR_STUN_DOT_ORBIT,
+  PREDATOR_STUN_DOT_RADIUS,
+  PREDATOR_STUN_ORBIT_WOBBLE,
 } from './constants';
 
 // 捕食者（サメ）をピクセルアートとしてCanvasに描画する
@@ -40,32 +42,32 @@ export function drawPredator(ctx: CanvasRenderingContext2D, predator: Predator):
 
   // しびれ中は黄色ドットエフェクトを描画
   if (predator.isStunned) {
-    drawStunEffect(ctx, predator);
+    const now = performance.now();
+    drawStunEffect(ctx, predator, now);
   }
 }
 
 // しびれエフェクト：黄色ドットが捕食者の周囲を回転する
-function drawStunEffect(ctx: CanvasRenderingContext2D, predator: Predator): void {
-  const now = performance.now();
+function drawStunEffect(ctx: CanvasRenderingContext2D, predator: Predator, now: number): void {
   // sin 波による点滅（0.7〜1.0 の範囲でアルファを変化）
-  const blink = 0.5 + 0.5 * Math.sin(now * 0.01);
+  const blink = 0.7 + 0.3 * (0.5 + 0.5 * Math.sin(now * 0.01));
 
   ctx.save();
   ctx.shadowBlur  = 10;
   ctx.shadowColor = PREDATOR_STUN_COLOR;
   ctx.fillStyle   = PREDATOR_STUN_COLOR;
-  ctx.globalAlpha = 0.7 + 0.3 * blink;
+  ctx.globalAlpha = blink;
 
   for (let i = 0; i < PREDATOR_STUN_DOT_COUNT; i++) {
     // フレームごとに回転し、各ドットを等間隔に配置
     const angle = now * 0.003 + (i * Math.PI * 2) / PREDATOR_STUN_DOT_COUNT;
     // 振動で軌道半径をわずかに変化させてしびれ感を演出
-    const orbit = PREDATOR_STUN_DOT_ORBIT + 4 * Math.sin(now * 0.008 + i);
+    const orbit = PREDATOR_STUN_DOT_ORBIT + PREDATOR_STUN_ORBIT_WOBBLE * Math.sin(now * 0.008 + i);
     const dotX  = predator.x + Math.cos(angle) * orbit;
     const dotY  = predator.y + Math.sin(angle) * orbit;
 
     ctx.beginPath();
-    ctx.arc(dotX, dotY, 3, 0, Math.PI * 2);
+    ctx.arc(dotX, dotY, PREDATOR_STUN_DOT_RADIUS, 0, Math.PI * 2);
     ctx.fill();
   }
 

--- a/app/src/features/boids/lib/webgpuRenderer.ts
+++ b/app/src/features/boids/lib/webgpuRenderer.ts
@@ -12,6 +12,8 @@ import {
   PREDATOR_STUN_COLOR,
   PREDATOR_STUN_DOT_COUNT,
   PREDATOR_STUN_DOT_ORBIT,
+  PREDATOR_STUN_DOT_RADIUS,
+  PREDATOR_STUN_ORBIT_WOBBLE,
   CRT_SCANLINE_INTERVAL,
   CRT_SCANLINE_OPACITY,
   CRT_VIGNETTE_INNER_RADIUS,
@@ -60,6 +62,9 @@ const SHARK_PIXEL_OFFSETS = computeFilledPixels(SHARK_SPRITE, PREDATOR_PIXEL_SIZ
 
 // しびれドット用：オフセット(0,0)の1点スプライト
 const STUN_DOT_PIXEL_OFFSETS: PixelOffset[] = [{ ox: 0, oy: 0 }];
+
+// しびれエフェクトのドット色をモジュール初期化時に1回だけ変換してキャッシュ
+const STUN_DOT_RGB = hexToRgb(PREDATOR_STUN_COLOR);
 
 // ────── バッファレイアウト定数 ─────────────────────────────────────────────
 
@@ -388,17 +393,17 @@ export class WebGPURenderer implements BoidsRenderer {
     // しびれ中は黄色ドットエフェクトを描画
     if (predator.isStunned) {
       const now = performance.now();
-      const [dr, dg, db] = hexToRgb(PREDATOR_STUN_COLOR);
+      const [dr, dg, db] = STUN_DOT_RGB;
       // sin 波による点滅（0.7〜1.0 の範囲でアルファを変化）
       const blink = 0.7 + 0.3 * (0.5 + 0.5 * Math.sin(now * 0.01));
       for (let i = 0; i < PREDATOR_STUN_DOT_COUNT; i++) {
         // フレームごとに回転し、各ドットを等間隔に配置
         const angle = now * 0.003 + (i * Math.PI * 2) / PREDATOR_STUN_DOT_COUNT;
         // 振動で軌道半径をわずかに変化させてしびれ感を演出
-        const orbit = PREDATOR_STUN_DOT_ORBIT + 4 * Math.sin(now * 0.008 + i);
+        const orbit = PREDATOR_STUN_DOT_ORBIT + PREDATOR_STUN_ORBIT_WOBBLE * Math.sin(now * 0.008 + i);
         const dotX  = predator.x + Math.cos(angle) * orbit;
         const dotY  = predator.y + Math.sin(angle) * orbit;
-        addSprite(dotX, dotY, 0, STUN_DOT_PIXEL_OFFSETS, 3, dr, dg, db, blink);
+        addSprite(dotX, dotY, 0, STUN_DOT_PIXEL_OFFSETS, PREDATOR_STUN_DOT_RADIUS, dr, dg, db, blink);
       }
     }
 


### PR DESCRIPTION
## 概要

クラゲ（Jellyfish）を捕食した捕食者（サメ）が一定時間しびれ状態になる機能を実装しました。

## 変更内容

- **Predator.ts**: `_stunnedUntil` フィールドと `isStunned` ゲッターを追加。クラゲ捕食時にしびれ状態を設定し、しびれ中は移動を停止する
- **constants.ts**: しびれエフェクトのパラメータを定義（持続時間 3000ms、ドット数、軌道半径、色）
- **predatorRenderer.ts**: Canvas2D レンダラーにしびれエフェクト（黄色ドットが周囲を回転）を追加
- **webgpuRenderer.ts**: WebGPU レンダラーにも同様のしびれエフェクトを追加

## テスト方法

- [ ] クラゲを捕食者が食べた後、3秒間移動が停止することを確認
- [ ] 黄色ドットが捕食者の周囲を回転するエフェクトが表示されることを確認
- [ ] Canvas2D・WebGPU 両レンダラーで正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

close #26