### PR TITLE
バグ: サメがクラゲを捕食して痺れると方向が必ず右を向く

### DIFF
--- a/app/src/features/boids/lib/Predator.ts
+++ b/app/src/features/boids/lib/Predator.ts
@@ -207,7 +207,7 @@ export class Predator {
       this.vx = vel.x;
       this.vy = vel.y;
 
-      // 速度が有効なうちに進行方向角度を更新（しびれ発生時に _lastAngle が参照される）
+      // 速度がゼロでない間は角度を更新する（しびれ中は vx/vy がゼロになるため、しびれ突入直前の角度が _lastAngle に保持される）
       if (this.vx !== 0 || this.vy !== 0) {
         this._lastAngle = Math.atan2(this.vy, this.vx);
       }

--- a/app/src/features/boids/lib/Predator.ts
+++ b/app/src/features/boids/lib/Predator.ts
@@ -36,6 +36,8 @@ export class Predator {
   private _confusionAngleChangedAt: number;
   // クラゲ捕食後の再捕食クールダウン終了時刻（0 = クールダウンなし）
   private _jellyfishCooldownUntil: number;
+  // 直前の進行方向角度（vx/vy がゼロのしびれ中でも向きを保持するために使用）
+  private _lastAngle: number;
 
   get satiety(): number {
     return this._satiety;
@@ -44,6 +46,11 @@ export class Predator {
   // 現在しびれ状態かどうか
   get isStunned(): boolean {
     return performance.now() < this._stunnedUntil;
+  }
+
+  // 描画用の進行方向角度（しびれ中は vx/vy がゼロになるため直前の角度を返す）
+  get angle(): number {
+    return this._lastAngle;
   }
 
   // 現在混乱状態かどうか（しびれ中は混乱を無効化）
@@ -75,6 +82,7 @@ export class Predator {
     const angle = Math.random() * Math.PI * 2;
     this.vx = Math.cos(angle) * PREDATOR_SPEED;
     this.vy = Math.sin(angle) * PREDATOR_SPEED;
+    this._lastAngle = angle;
   }
 
   // ラップアラウンドを考慮したBoidへの相対位置ベクトルを返す
@@ -198,6 +206,11 @@ export class Predator {
       const vel = limit(this.vx, this.vy, effectiveSpeed);
       this.vx = vel.x;
       this.vy = vel.y;
+
+      // 速度が有効なうちに進行方向角度を更新（しびれ発生時に _lastAngle が参照される）
+      if (this.vx !== 0 || this.vy !== 0) {
+        this._lastAngle = Math.atan2(this.vy, this.vx);
+      }
 
       this.x += this.vx;
       this.y += this.vy;

--- a/app/src/features/boids/lib/predatorRenderer.ts
+++ b/app/src/features/boids/lib/predatorRenderer.ts
@@ -21,8 +21,8 @@ export function drawPredator(ctx: CanvasRenderingContext2D, predator: Predator):
 
   ctx.save();
   ctx.translate(predator.x, predator.y);
-  // 進行方向に向けて回転（Boidと同じ規則）
-  ctx.rotate(Math.atan2(predator.vy, predator.vx) + Math.PI / 2);
+  // 進行方向に向けて回転（しびれ中は vx/vy がゼロになるため angle ゲッターで保持した角度を使用）
+  ctx.rotate(predator.angle + Math.PI / 2);
 
   ctx.shadowBlur  = 20;
   ctx.shadowColor = PREDATOR_COLOR;

--- a/app/src/features/boids/lib/webgpuRenderer.ts
+++ b/app/src/features/boids/lib/webgpuRenderer.ts
@@ -559,7 +559,8 @@ export class WebGPURenderer implements BoidsRenderer {
     {
       const halfSize = PREDATOR_PIXEL_SIZE / 2;
       const [r, g, b] = hexToRgb(PREDATOR_COLOR);
-      const angle = Math.atan2(predator.vy, predator.vx) + Math.PI / 2;
+      // しびれ中は vx/vy がゼロになるため angle ゲッターで保持した角度を使用
+      const angle = predator.angle + Math.PI / 2;
       addSprite(predator.x, predator.y, angle, SHARK_PIXEL_OFFSETS, halfSize, r, g, b);
     }
 


### PR DESCRIPTION
## 概要

サメがしびれ状態中に `vx/vy` がゼロになるため、`Math.atan2(0, 0) = 0`（右向き）が返され、スプライトが常に右を向いてしまうバグを修正します。

## 変更点

- `Predator.ts`: `_lastAngle` フィールドを追加し、速度が有効なうちに進行方向角度を記録する。`angle` ゲッターで外部に公開する
- `predatorRenderer.ts`: `Math.atan2(predator.vy, predator.vx)` の代わりに `predator.angle` を使用
- `webgpuRenderer.ts`: 同様に `predator.angle` を使用

Closes #41